### PR TITLE
Ensure setId is integer

### DIFF
--- a/modbus-serial.js
+++ b/modbus-serial.js
@@ -70,6 +70,7 @@ module.exports = function(RED) {
       node.processing = true;
       if (node.requests.length != 0) {
         var obj = node.requests.pop();
+        obj.id = +obj.id;
         var promise;
         switch(obj.type) {
           case 'readCoils':


### PR DESCRIPTION
`node.client.setID(...)` must be an integer. At the moment, the parameter comes from `obj.id`, which might be a string.
So this PR forces `obj.id` to be a number.